### PR TITLE
Fix bug where some words lose initial letter & acronyms removed

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -19,7 +19,7 @@ export function removeMarkdown(text: string): string {
 		.replace(/\[([\s\S]*?)\]/g, '$1')//normal brackets[]
 		.replace(/\(([\s\S]*?)\)/g, '$1')//normal brackets()
 		.replace(/^(.*?)::(.*?)$/gm, '') //dataview inline attributes
-		.replace(/[,.;:|#-()=_*-^\[\]]/g, '')
+		.replace(/[,.;:|#()=_*^\[\]-]/g, '')
 		.replace(/<("[^"]*"|'[^']*'|[^'">])*>/gm, '') //html (regex from: https://www.data2type.de/xml-xslt-xslfo/regulaere-ausdruecke/regex-methoden-aus-der-praxis/beispiele-zu-html/html-tags-erkennen)
 		.replace(/\s\S\s/g, ' ') //single chars;
 }


### PR DESCRIPTION
Fixes Issue #7: Most words have the first character missing and acronyms and numbers are removed completely

This regex was matching on initial capital letters, numbers and acronyms/TLRs.