### PR TITLE
feat: allow query for word cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ source: file
 ```
 ~~~
 
+#### Show all words using a folder/file
+
+~~~markdown
+```wordcloud
+source: file
+query: 'Folder/File'
+```
+~~~
+
 ### Options
 
 | **Name**  | **Description**                                                                                                 | **Possible Values** | **Default** |

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -10,7 +10,7 @@ export function removeMarkdown(text: string): string {
 		.replace(/\[\[(.*(?=\|))(.*)\]\]/g, '$2') //wikilinks with alias
 		.replace(/\[\[([\s\S]*?)\]\]/gm, '$1') //wikilinks
 		.replace(/- ?\[.?\]/gm, '') //tasks
-		.replace(/%%.*?%%/gm, '')//Obsidian Comments
+		.replace(/%%(.|\n)*?%%/gm, '')//Obsidian Comments
 		.replace(/`([\s\S]*?)`/gm, '') //codeblocks, inline & normal
 		.replace(/\[\^[[\s\S]]*\]/g, '') //footnotes
 		.replace(/\^\[([\s\S]*?)\]/g, '$1') //inline footnotes
@@ -36,20 +36,13 @@ export function removeStopwords(words: Record<string, number>, customStopwords: 
 }
 
 export async function getWords(text: string): Promise<string[]> {
-	const words = text.split(/[\n\s]/g);
-	const output: string[] = [];
-	for (let word of words) {
-		const result = removeMarkdown(word).toLocaleLowerCase();
-		if(result.length > 0) {
-			output.push(result);
-		}
-	}
-	return output;
+	const cleanText = removeMarkdown(text).toLocaleLowerCase();
+	return cleanText.split(/[\n\s]/g);
 }
 
 export async function convertToMap(words: string[]): Promise<Record<string, number>> {
 	const record: Record<string, number> = {};
-	for (let word of words) {
+	for (const word of words) {
 		const element = record[word];
 		if(element) {
 			record[word] = element + 1;

--- a/src/wordcloud.ts
+++ b/src/wordcloud.ts
@@ -74,35 +74,18 @@ export class Wordcloud {
 				const rawContent = await dataviewAPI.io.load(page.file.path)
 				const parsedWords = await getWords(rawContent)
 				content = await convertToMap(parsedWords);
+
+				if(options.stopwords) {
+					const tmp = this.plugin.settings.stopwords.split("\n");
+					const customStopwords = new Set<string>(tmp);
+					content = removeStopwords(content, customStopwords)
+				}
 			} catch (error: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
 				el.createEl('p', {cls: "cloud-error"}).setText(error.toString());
 				logger.error(error);
 				return;
 			}
 		}
-		/*this part is really not performant, need to find a better solution.
-		if(options.source === 'query') {
-			const dataviewAPI = getAPI();
-			if(dataviewAPI === undefined) {
-				el.createEl("p").setText("Dataview is not installed, but is required to use queries");
-				return;
-			}
-
-			const pages = dataviewAPI.pages(options.query, ctx.sourcePath);
-			const words : string[] = [];
-			for (let page of pages) {
-				const file = this.app.vault.getAbstractFileByPath(page.file.path);
-				if (file === undefined) return;
-				if (!(file instanceof TFile)) return;
-				const fileContent = await this.app.vault.read(file);
-				words.push(...this.getWords(fileContent));
-			}
-			if(options.stopwords) {
-				content = this.convertToMap(this.removeStopwords(words));
-			}else {
-				content = this.convertToMap(words);
-			}
-		}*/
 
 		el.empty();
 

--- a/src/wordcloud.ts
+++ b/src/wordcloud.ts
@@ -1,5 +1,6 @@
-import TagCloudPlugin from "./main";
+import TagCloudPlugin, {logger} from "./main";
 import {MarkdownPostProcessorContext, TFile} from "obsidian";
+import {getAPI} from "obsidian-dataview";
 import {convertToMap, getWords, recordToArray, removeStopwords} from "./functions";
 import WordCloud from "wordcloud";
 
@@ -50,8 +51,34 @@ export class Wordcloud {
 			}
 		}
 		if (options.source === 'query') {
-			el.createEl("p", {cls: "cloud-error"}).setText("Queries are not supported in a wordcloud");
-			return;
+			const dataviewAPI = getAPI();
+			if (dataviewAPI === undefined) {
+				el.createEl("p", {cls: "cloud-error"}).setText("Dataview is not installed, but is required to use queries");
+				return;
+			}
+
+			try {
+				const query = options.query;
+				if(!query) {
+					el.createEl('p', {cls: "cloud-error"}).setText("query option is required");
+					return;
+				}
+
+				const page = dataviewAPI.page(query);
+
+				if(!page) {
+					el.createEl('p', {cls: "cloud-error"}).setText("Page not found");
+					return;
+				}
+
+				const rawContent = await dataviewAPI.io.load(page.file.path)
+				const parsedWords = await getWords(rawContent)
+				content = await convertToMap(parsedWords);
+			} catch (error: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
+				el.createEl('p', {cls: "cloud-error"}).setText(error.toString());
+				logger.error(error);
+				return;
+			}
 		}
 		/*this part is really not performant, need to find a better solution.
 		if(options.source === 'query') {


### PR DESCRIPTION
Hi @joethei! Thanks for creating this plugin.

I have made improvements that resolves https://github.com/joethei/obsidian-tagcloud/issues/10

Main changes:
- Sanitizes the markdown before separating it into words
    - This removes code blocks, comment blocks, etc.
- uses `dataviewAPI.io.load` to get contents from another file


Old word cloud before sanitation fix:

<img width="695" alt="image" src="https://github.com/joethei/obsidian-tagcloud/assets/13763624/c3c10556-c1bc-47e1-8323-8cafbca9703e">


New word cloud:

<img width="638" alt="image" src="https://github.com/joethei/obsidian-tagcloud/assets/13763624/72076e2f-7bb3-448b-a043-16c93fa57611">
